### PR TITLE
Limit websocket-client up to 0.48

### DIFF
--- a/samples/CraftPython/README.md
+++ b/samples/CraftPython/README.md
@@ -23,7 +23,7 @@ pip3 install wxpython
 
 Install `websocket-client` from command line: <br/>
 ```
-pip3 install websocket-client
+pip3 install websocket-client==0.48
 ```
 
 Install `pyinstaller` from the command line: <br/>


### PR DESCRIPTION
For current sample code, websocket-client version need to be limited up to 0.48.
Other solution is update sample code for latest websocket-client library.